### PR TITLE
Messages frontend updates

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -2,8 +2,10 @@ class ConversationsController < ApplicationController
   def index
     matches = Match.matches_for_user(current_user.id)
     @conversations = matches.map(&:conversation)
-    # conversation_last_message = Conversation.find(params[:id])
     @new_message = Message.new
+
+    # set_has_unread_messages(conversations: @conversations)
+    # raise
   end
 
   def show

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -73,7 +73,7 @@ class MatchesController < ApplicationController
       match = Match.new(sender_id: current_user.id, receiver_id: profile_id, senderstatus: false)
     end
 
-    Conversation.create(lastmessage: 'Test')
+    # Conversation.create(lastmessage: 'Test')
     if match.save!
       redirect_to matches_path
     end

--- a/app/controllers/messaging_timestamps_controller.rb
+++ b/app/controllers/messaging_timestamps_controller.rb
@@ -1,0 +1,18 @@
+class MessagingTimestampsController < ApplicationController
+  def subscribe
+    timestamp = MessagingTimestamp.new
+    timestamp.conversation = Conversation.find(params[:conversation_id])
+    timestamp.user = current_user
+    timestamp.action = "signin"
+    MessagingTimestamp.where(user: current_user, action: "signout").destroy_all if timestamp.save
+  end
+
+  def unsubscribe
+    timestamp = MessagingTimestamp.new
+    timestamp.conversation = Conversation.find(params[:conversation_id])
+    timestamp.user = current_user
+    timestamp.action = "signout"
+    MessagingTimestamp.where(user: current_user, action: "signin").destroy_all if timestamp.save
+    # redirect_to timestamp.conversation
+  end
+end

--- a/app/javascript/controllers/conversation_subscription_controller.js
+++ b/app/javascript/controllers/conversation_subscription_controller.js
@@ -4,15 +4,33 @@ import { createConsumer } from "@rails/actioncable"
 
 // Connects to data-controller="conversation-subscription"
 export default class extends Controller {
-  static values = { conversationId: Number }
+  static values = { conversationId: Number}
   static targets = ["messages"]
 
   connect() {
     this.channel = createConsumer().subscriptions.create(
       { channel: "ConversationChannel", id: this.conversationIdValue },
+
       {received: data => this.messagesTarget.insertAdjacentHTML("beforeend", data)},
 
       { received: data => console.log(data) }
     )
+    $.ajax({
+      url: "/messaging_timestamps/subscribe",
+      data: {
+        conversation_id: this.conversationIdValue
+      }
+    })
+  }
+
+  disconnect(){
+    console.log('disconnected')
+    $.ajax({
+      url: "/messaging_timestamps/unsubscribe",
+      data: {
+        conversation_id: this.conversationIdValue
+      }
+    })
+
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -21,3 +21,6 @@ application.register("matches", MatchesController)
 
 import ResetFormController from "./reset_form_controller"
 application.register("reset-form", ResetFormController)
+
+import ScrollController from "./scroll_controller"
+application.register("scroll", ScrollController)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,13 +10,14 @@ application.register("conversation-subscription", ConversationSubscriptionContro
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import LoaderController from "./loader_controller"
+application.register("loader", LoaderController)
 
 import MapController from "./map_controller"
 application.register("map", MapController)
 
-import LoaderController from "./loader_controller"
-application.register("loader", LoaderController)
-
-
 import MatchesController from "./matches_controller"
 application.register("matches", MatchesController)
+
+import ResetFormController from "./reset_form_controller"
+application.register("reset-form", ResetFormController)

--- a/app/javascript/controllers/reset_form_controller.js
+++ b/app/javascript/controllers/reset_form_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="reset-form"
+export default class extends Controller {
+  reset() {
+    this.element.reset();
+  }
+}

--- a/app/javascript/controllers/scroll_controller.js
+++ b/app/javascript/controllers/scroll_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="scroll"
+export default class extends Controller {
+  // on start
+  connect() {
+    console.log("connected");
+    const messages = document.getElementById("messages");
+    messages.addEventListener("DOMNodeInserted", this.resetScroll);
+    this.resetScroll(messages);
+  }
+
+  disconnect() {
+    console.log("disconnected");
+
+  }
+
+  resetScroll() {
+    messages.scrollTop = messages.scrollHeight - messages.clientHeight;
+
+  }
+}

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,4 +1,14 @@
 class Conversation < ApplicationRecord
   has_many :messages
+  has_many :messaging_timestamps
   belongs_to :match
+
+  def unread_messages?(current_user:)
+    latest_message_timestamp = messages.where.not(user: current_user).order(:created_at).last&.created_at ||
+                               5.days.from_now
+    messaging_timestamp = messaging_timestamps.where(action: "signout", user: current_user).first&.created_at ||
+                          match.created_at
+                          # raise
+    latest_message_timestamp > messaging_timestamp
+  end
 end

--- a/app/models/messaging_timestamp.rb
+++ b/app/models/messaging_timestamp.rb
@@ -1,0 +1,4 @@
+class MessagingTimestamp < ApplicationRecord
+  belongs_to :user
+  belongs_to :conversation
+end

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -38,9 +38,11 @@
           </div>
               <div class = "card-product-infos d-flex flex-column justify-content-center">
               <%# to be updated with a stimulus controller to listen for when an unread message has been created %>
-              <div class= "new-message-notification"></div>
-
-              <div class= "no-new-message"></div>
+              <% if conversation.unread_messages?(current_user:) %>
+                <div class= "new-message-notification"></div>
+              <% else %>
+                <div class= "no-new-message"></div>
+              <% end %>
 
           </div>
         </div>

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -3,7 +3,7 @@
 >
   <h1>Room #<%= @conversation.id %></h1>
 
-  <div class="messages" data-conversation-subscription-target="messages">
+  <div class="messages" id="messages" data-conversation-subscription-target="messages" data-controller="scroll">
     <% @conversation.messages.each do |message| %>
      <%= render "messages/message", message: message %>
     <% end %>

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -9,7 +9,8 @@
     <% end %>
   </div>
 
-  <%= simple_form_for [@conversation, @message], html: {class: "d-flex"} do |f| %>
+  <%= simple_form_for [@conversation, @message], html: {class: "d-flex"},
+  data: { controller: "reset-form", action: "turbo:submit-end->reset-form#reset"} do |f| %>
     <%= f.input :content,
       label: false,
       placeholder: "Send message",

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -1,6 +1,5 @@
 <div class="container chatroom" data-controller="conversation-subscription"
-  data-conversation-subscription-conversation-id-value="<%= @conversation.id %>"
->
+  data-conversation-subscription-conversation-id-value="<%= @conversation.id %>">
   <h1>Room #<%= @conversation.id %></h1>
 
   <div class="messages" id="messages" data-conversation-subscription-target="messages" data-controller="scroll">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <link href="https://api.mapbox.com/mapbox-gl-js/v2.11.0/mapbox-gl.css" rel="stylesheet">
-    <script src="https://api.mapbox.com/mapbox-gl-js/v2.11.0/mapbox-gl.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js">   </script>
     <style>
 
     </style>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
 
   resources :users, only: [:edit, :update]
   get "users/:id", to: "users#show", as: :show_user
+  get "messaging_timestamps/subscribe", to: "messaging_timestamps#subscribe"
+  get "messaging_timestamps/unsubscribe", to: "messaging_timestamps#unsubscribe"
   get "users/me/:id",to: "users#me", as: :my_profile
   get "users/new/:id", to: "users#new", as: :new_user_match
   resources :genres, only: [:index]

--- a/db/migrate/20230622180834_add_read_status_to_messages.rb
+++ b/db/migrate/20230622180834_add_read_status_to_messages.rb
@@ -1,0 +1,5 @@
+class AddReadStatusToMessages < ActiveRecord::Migration[7.0]
+  def change
+      add_column :messages, :read_status, :boolean
+  end
+end

--- a/db/migrate/20230622191640_create_messaging_timestamps.rb
+++ b/db/migrate/20230622191640_create_messaging_timestamps.rb
@@ -1,0 +1,11 @@
+class CreateMessagingTimestamps < ActiveRecord::Migration[7.0]
+  def change
+    create_table :messaging_timestamps do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :conversation, null: false, foreign_key: true
+      t.string :action
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230624093100_change_last_message_to_has_unread_messages.rb
+++ b/db/migrate/20230624093100_change_last_message_to_has_unread_messages.rb
@@ -1,0 +1,6 @@
+class ChangeLastMessageToHasUnreadMessages < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :conversations, :lastmessage
+    add_column :conversations, :has_unread_messages, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_16_141243) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_24_093100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,10 +67,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_16_141243) do
   end
 
   create_table "conversations", force: :cascade do |t|
-    t.string "lastmessage"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "match_id"
+    t.boolean "has_unread_messages", default: false
     t.index ["match_id"], name: "index_conversations_on_match_id"
   end
 
@@ -103,8 +103,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_16_141243) do
     t.string "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "read_status"
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
+  create_table "messaging_timestamps", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "conversation_id", null: false
+    t.string "action"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["conversation_id"], name: "index_messaging_timestamps_on_conversation_id"
+    t.index ["user_id"], name: "index_messaging_timestamps_on_user_id"
   end
 
   create_table "user_genres", force: :cascade do |t|
@@ -152,6 +163,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_16_141243) do
   add_foreign_key "matches", "users", column: "sender_id"
   add_foreign_key "messages", "conversations"
   add_foreign_key "messages", "users"
+  add_foreign_key "messaging_timestamps", "conversations"
+  add_foreign_key "messaging_timestamps", "users"
   add_foreign_key "user_genres", "genres"
   add_foreign_key "user_genres", "users"
   add_foreign_key "user_instruments", "instruments"

--- a/test/controllers/messaging_timestamps_controller_test.rb
+++ b/test/controllers/messaging_timestamps_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MessagingTimestampsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/messaging_timestamp_test.rb
+++ b/test/models/messaging_timestamp_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MessagingTimestampTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Auto cleared chat form and quality of life updates form the conversations show page 

AND

new logic to implement an unread messages:

new model 'messaging_timestamp' which belongs to user and conversation models 

new controller 'messaging_timestamps to store incoming and outgoing timestamps on the conversations show (chatroom)

updated 'conversations_subscription' stimulus controller to capture when user is looking at the chatroom. this this allows the 'messaging_controller' to capture the timestamp data
